### PR TITLE
fix typo in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
                         <td data-label="Usage"><a translate="commandsUsage.commands" href="command_examples/commands.png" data-lightbox="commands"></a></td>
                     </tr>
                     <tr class="slightlyColored">
-                        <td data-label="Command" class="pinkBg">!b disable/enable</td>
+                        <td data-label="Command" class="pinkBg">!r disable/enable</td>
                         <td translate="commandsDesc.disableEnable" data-label="Description"></td>
                         <td data-label="Usage"><a translate="commandsUsage.disableEnable" href="command_examples/disableEnable.png" data-lightbox="disableEnable"></a></td>
                     </tr>


### PR DESCRIPTION
Should this be `!r disable/enable` instead of `!b disable/enable`? 